### PR TITLE
sudo mode for OpenLiteSpeed on startup/shutdown

### DIFF
--- a/src/Test/Proxy/LiteSpeedProxy.php
+++ b/src/Test/Proxy/LiteSpeedProxy.php
@@ -15,7 +15,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class LiteSpeedProxy extends AbstractProxy
 {
-    protected $binary = '/usr/local/lsws/bin/lswsctrl';
+    protected $binary = '/usr/bin/sudo /usr/local/lsws/bin/lswsctrl';
 
     protected $port = 8080;
 

--- a/tests/install-openlitespeed.sh
+++ b/tests/install-openlitespeed.sh
@@ -1,14 +1,9 @@
 #!/bin/sh
 
-sudo apt-get -y install build-essential
-sudo apt-get -y install rcs libpcre3-dev libexpat1-dev libssl-dev libgeoip-dev libudns-dev zlib1g-dev libxml2 libxml2-dev libpng-dev openssl
-sudo apt-get -y install wget
+wget -O - http://rpms.litespeedtech.com/debian/enable_lst_debain_repo.sh | sudo bash
+sudo apt-get -y install openlitespeed
 
-wget https://openlitespeed.org/packages/openlitespeed-1.4.43.src.tgz
-tar -zxvf openlitespeed-1.4.43.src.tgz
-cd ./openlitespeed-1.4.43
-./configure --with-user travis --with-group travis
-make && make install
+sudo /usr/local/lsws/bin/lswsctrl stop
 
 # Remove examples
 sudo rm -r /usr/local/lsws/conf/vhosts/Example


### PR DESCRIPTION
It's very diffucult to run a OpenLiteSpeed server under a non-root user privileges. Start server fpr test coverage with the root user (sudo) in travis-ci.